### PR TITLE
Use simple-phpunit instead of phpunit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,11 +84,11 @@ test: tu tf
 
 tu: ## Run unit tests
 tu: vendor
-	$(EXEC_PHP) bin/phpunit --exclude-group functional
+	$(EXEC_PHP) vendor/bin/simple-phpunit --exclude-group functional
 
 tf: ## Run functional tests
 tf: vendor
-	$(EXEC_PHP) bin/phpunit --group functional
+	$(EXEC_PHP) vendor/bin/simple-phpunit --group functional
 
 .PHONY: test tu tf
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,8 @@
         <!-- Configure your db driver and server_version in config/packages/doctrine.yaml -->
         <env name="DATABASE_URL" value="mysql://db_user:db_password@127.0.0.1:3306/db_name"/>
         <!-- ###- doctrine/doctrine-bundle ### -->
+        
+        <server name="SYMFONY_PHPUNIT_VERSION" value="8"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
As per the Symfony Bridge documentation
This PR also set the v8.x as default PHPUnit version