### PR TITLE
Redondant values removed + correct env

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,14 +10,12 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="KERNEL_CLASS" value="App\Kernel" />
-        <env name="APP_ENV" value="test" />
         <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
         <env name="SHELL_VERBOSITY" value="-1" />
         <!-- define your env variables for the test env here -->
 
         <!-- ###+ symfony/framework-bundle ### -->
-        <env name="APP_ENV" value="dev"/>
+        <env name="APP_ENV" value="test"/>
         <env name="APP_SECRET" value="9b1f3b94a999b6657f8a5d12a63ad5b7"/>
         <!-- env name="TRUSTED_PROXIES" value="127.0.0.1,127.0.0.2" -->
         <!-- env name="TRUSTED_HOSTS" value="'^localhost|example\.com$'" -->


### PR DESCRIPTION
This PR removes redondant values in the PHPUnit configuration and set the correct `test` env